### PR TITLE
Prepare v0.32.0 release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,16 +29,15 @@ changelog:
       - '^release'
 dockers:
   - image_templates:
-      - "docker.io/aquasec/harbor-scanner-trivy:{{ .Version }}"
-      - "public.ecr.aws/aquasecurity/harbor-scanner-trivy:{{ .Version }}"
+      - "docker.io/goharbor/harbor-scanner-trivy:{{ .Version }}"
     ids:
       - scanner-trivy
     build_flag_templates:
       - "--label=org.label-schema.schema-version=1.0"
       - "--label=org.label-schema.name={{ .ProjectName }}"
       - "--label=org.label-schema.description=Harbor scanner adapter for Trivy"
-      - "--label=org.label-schema.vendor=Aqua Security"
+      - "--label=org.label-schema.vendor=Harbor community"
       - "--label=org.label-schema.version={{ .Version }}"
       - "--label=org.label-schema.build-date={{ .Date }}"
-      - "--label=org.label-schema.vcs=https://github.com/aquasecurity/harbor-scanner-trivy"
+      - "--label=org.label-schema.vcs=https://github.com/goharbor/harbor-scanner-trivy"
       - "--label=org.label-schema.vcs-ref={{ .FullCommit }}"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following matrix indicates the version of Trivy and Trivy adapter installed 
 
 | Harbor                  | Trivy Adapter | Trivy           |
 |-------------------------|---------------|-----------------|
+| harbor v2.12.0          | v0.32.0       | [trivy v0.56.1] |
 | harbor v2.11.1          | v0.31.4       | [trivy v0.54.1] |
 | -                       | v0.31.3       | [trivy v0.52.2] |
 | harbor v2.11.0          | v0.31.2       | [trivy v0.51.2] |

--- a/helm/harbor-scanner-trivy/Chart.yaml
+++ b/helm/harbor-scanner-trivy/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 name: harbor-scanner-trivy
-version: 0.31.4
-appVersion: 0.31.4
+version: 0.32.0
+appVersion: 0.32.0
 description: Harbor scanner adapter for Trivy
 keywords:
   - scanner
   - harbor
   - vulnerability
 sources:
-- https://github.com/aquasecurity/harbor-scanner-trivy
+- https://github.com/goharbor/harbor-scanner-trivy

--- a/helm/harbor-scanner-trivy/values.yaml
+++ b/helm/harbor-scanner-trivy/values.yaml
@@ -3,8 +3,8 @@ fullnameOverride: ""
 
 image:
   registry: docker.io
-  repository: aquasec/harbor-scanner-trivy
-  tag: 0.31.4
+  repository: goharbor/harbor-scanner-trivy
+  tag: 0.32.0
   pullPolicy: IfNotPresent
 
 replicaCount: 1
@@ -98,7 +98,7 @@ scanner:
     gitHubToken: ""
     ## insecure the flag to skip verifying registry certificate
     insecure: false
-    # See https://github.com/aquasecurity/trivy#filter-the-vulnerabilities-by-open-policy-agent-policy for details
+    # See https://github.com/goharbor/trivy#filter-the-vulnerabilities-by-open-policy-agent-policy for details
     ignorePolicy: ""
     # ignorePolicy:  |
     #  package trivy


### PR DESCRIPTION
1. Update the release settings to publish image to goharbor namespace on docker hub
2. Update the version and image reference of helm chart