### PR TITLE
Fix issues in goreleaser yaml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,8 +18,6 @@ archives:
       amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
-snapshot:
-  name_template: "{{ .FullCommit }}"
 changelog:
   sort: asc
   filters:
@@ -29,7 +27,7 @@ changelog:
       - '^release'
 dockers:
   - image_templates:
-      - "docker.io/goharbor/harbor-scanner-trivy:{{ .Version }}"
+      - "docker.io/goharbor/harbor-scanner-trivy:{{ .Tag }}"
     ids:
       - scanner-trivy
     build_flag_templates:


### PR DESCRIPTION
For some reason when v0.32.2 was tagged, goreleaser was still trying to build v0.32.2-rc.2 and caused some issue.
This commit is an attempt to fix it by removing "snapshot" section and use the tag as the tag of docker image.