### PR TITLE
Workaround goreleaser issue

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ changelog:
       - '^release'
 dockers:
   - image_templates:
-      - "docker.io/goharbor/harbor-scanner-trivy:{{ .Tag }}"
+      - "docker.io/goharbor/harbor-scanner-trivy:{{ .Version }}"
     ids:
       - scanner-trivy
     build_flag_templates:


### PR DESCRIPTION
Pushing another commit to make sure the new version has a new commit ID. Will fix the goreleaser issue in next release.