### PR TITLE
feat: Add PURL field to vulnerability report

### DIFF
--- a/pkg/harbor/model.go
+++ b/pkg/harbor/model.go
@@ -155,6 +155,7 @@ type VulnerabilityItem struct {
 	Pkg              string         `json:"package"`
 	Version          string         `json:"version"`
 	Status           string         `json:"status,omitempty"`
+	PURL             string         `json:"purl,omitempty"`
 	FixVersion       string         `json:"fix_version,omitempty"`
 	Severity         Severity       `json:"severity"`
 	Description      string         `json:"description"`

--- a/pkg/scan/transformer.go
+++ b/pkg/scan/transformer.go
@@ -71,6 +71,7 @@ func (t *transformer) transformVulnerabilities(source []trivy.Vulnerability) []h
 			Pkg:              v.PkgName,
 			Version:          v.InstalledVersion,
 			Status:           v.Status,
+			PURL:             t.toPURL(v.PkgIdentifier),
 			FixVersion:       v.FixedVersion,
 			Severity:         t.toHarborSeverity(v.Severity),
 			Description:      v.Description,
@@ -109,6 +110,13 @@ func (t *transformer) toHarborLayer(tLayer *trivy.Layer) (hLayer *harbor.Layer) 
 		DiffID: tLayer.DiffID,
 	}
 	return
+}
+
+func (t *transformer) toPURL(pkgIdentifier *trivy.PkgIdentifier) string {
+	if pkgIdentifier == nil {
+		return ""
+	}
+	return pkgIdentifier.PURL
 }
 
 func (t *transformer) toHarborSeverity(severity string) harbor.Severity {

--- a/pkg/scan/transformer_test.go
+++ b/pkg/scan/transformer_test.go
@@ -43,6 +43,9 @@ func TestTransformer_Transform(t *testing.T) {
 				{
 					VulnerabilityID:  "CVE-0000-0001",
 					PkgName:          "PKG-01",
+					PkgIdentifier: &trivy.PkgIdentifier{
+						PURL: "pkg:deb/debian/pkg-01@1.0.0?arch=amd64&distro=debian-12",
+					},
 					InstalledVersion: "PKG-01-VER",
 					FixedVersion:     "PKG-01-FIX-VER",
 					Status:           "fixed",
@@ -149,6 +152,7 @@ func TestTransformer_Transform(t *testing.T) {
 				Pkg:         "PKG-01",
 				Version:     "PKG-01-VER",
 				Status:      "fixed",
+				PURL:        "pkg:deb/debian/pkg-01@1.0.0?arch=amd64&distro=debian-12",
 				FixVersion:  "PKG-01-FIX-VER",
 				Severity:    harbor.SevCritical,
 				Description: "CVE-0000-0001.DESC",

--- a/pkg/trivy/model.go
+++ b/pkg/trivy/model.go
@@ -32,6 +32,10 @@ type Layer struct {
 	DiffID string `json:"DiffID"`
 }
 
+type PkgIdentifier struct {
+	PURL string `json:"PURL"`
+}
+
 type CVSSInfo struct {
 	V2Vector string   `json:"V2Vector,omitempty"`
 	V3Vector string   `json:"V3Vector,omitempty"`
@@ -47,6 +51,7 @@ type Report struct {
 type Vulnerability struct {
 	VulnerabilityID  string              `json:"VulnerabilityID"`
 	PkgName          string              `json:"PkgName"`
+	PkgIdentifier    *PkgIdentifier      `json:"PkgIdentifier"`
 	InstalledVersion string              `json:"InstalledVersion"`
 	Status           string              `json:"Status"`
 	FixedVersion     string              `json:"FixedVersion"`


### PR DESCRIPTION
## Summary
  - Add PkgIdentifier struct to trivy model to capture PURL from scan results
  - Add PURL field to harbor VulnerabilityItem
  - Map PURL from Trivy's PkgIdentifier.PURL to Harbor's vulnerability report
  