### PR TITLE
chore: bump harbor-scanner-trivy to v0.37.2 and Trivy to v0.71.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # That's the only place where you're supposed to specify version of Trivy.
-ARG TRIVY_VERSION=0.71.1
+ARG TRIVY_VERSION=0.71.2
 
 FROM aquasec/trivy:${TRIVY_VERSION}
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 # That's the only place where you're supposed to specify version of Trivy.
-ARG TRIVY_VERSION=0.71.1
+ARG TRIVY_VERSION=0.71.2
 ARG SKAFFOLD_GO_GCFLAGS
 
 FROM golang:1.25 AS builder

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ lint:
 
 setup:
 	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.21.0
-	curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.71.1
+	curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.71.2
 
 submodule:
 	git submodule update --init --recursive

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following matrix indicates the version of Trivy and Trivy adapter installed 
 
 | Harbor                   | Trivy Adapter | Trivy           |
 |--------------------------|---------------|-----------------|
-| harbor v2.16.0           | v0.37.1       | [trivy v0.71.1] |
+| harbor v2.16.0           | v0.37.2       | [trivy v0.71.2] |
 | harbor v2.15.1           | v0.36.0       | [trivy v0.70.0] |
 | harbor v2.15.0           | v0.35.1       | [trivy v0.69.3] |
 | harbor v2.14.2           | v0.34.2       | [trivy v0.68.2] |

--- a/helm/harbor-scanner-trivy/Chart.yaml
+++ b/helm/harbor-scanner-trivy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: harbor-scanner-trivy
-version: 0.37.1
-appVersion: 0.37.1
+version: 0.37.2
+appVersion: 0.37.2
 description: Harbor scanner adapter for Trivy
 keywords:
   - scanner

--- a/helm/harbor-scanner-trivy/values.yaml
+++ b/helm/harbor-scanner-trivy/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 image:
   registry: docker.io
   repository: goharbor/harbor-scanner-trivy
-  tag: v0.37.1
+  tag: v0.37.2
   pullPolicy: IfNotPresent
 
 replicaCount: 1

--- a/test/component/component_test.go
+++ b/test/component/component_test.go
@@ -26,7 +26,7 @@ var (
 	trivyScanner = harbor.Scanner{
 		Name:    "Trivy",
 		Vendor:  "Aqua Security",
-		Version: "0.71.1",
+		Version: "0.71.2",
 	}
 )
 


### PR DESCRIPTION
## Summary
* Bump Trivy version from v0.71.1 to v0.71.2 and Trivy adapter version from v0.37.1 to v0.37.2 across relevant files, including Dockerfiles, Makefile, README, Helm chart, and component tests.

